### PR TITLE
MAINT: Add builds & artifact uploads for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
 
   build-wasm:
     name: "Build WASM"
+    needs: test
     runs-on: ubuntu-latest
     steps:
       # Check out the code
@@ -151,6 +152,7 @@ jobs:
 
   build-python-wheels:
     name: "Build Python Wheels"
+    needs: test
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -227,6 +229,7 @@ jobs:
 
   build-python-sdist:
     name: "Build Python Source Dist"
+    needs: test
     runs-on: ubuntu-latest
     steps:
       # Check out the code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,61 +95,6 @@ jobs:
           WINDOWS: "${{ contains(runner.os, 'windows') }}"
           PYTHON: ${{ steps.get-py-path.outputs.path }}
 
-  build-wasm:
-    name: "Build WASM"
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      # Check out the code
-      - uses: "actions/checkout@v2"
-
-      # Set the current month and year (used for cache key)
-      - name: "Get Date"
-        id: get-date
-        # Outputs e.g. "202007"
-        # tbh I have yet to find the docs where this output format is
-        # defined, but I copied this from the official cache action's README.
-        run: |
-          echo "::set-output name=date::$(/bin/date -u '+%Y%m')"
-        shell: bash
-
-      # Generate the lockfile
-      - name: "Generate Cargo Lockfile"
-        run: "cargo generate-lockfile"
-
-      # Cache build dependencies
-      - name: "Cache Build Fragments"
-        id: "cache-build-fragments"
-        uses: "actions/cache@v2"
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          # Rebuild whenever the cargo lock file changes
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      # Cache `cargo install` built binaries
-      - name: "Cache Built Binaries"
-        id: "cache-binaries"
-        uses: "actions/cache@v2"
-        with:
-          path: "~/.cargo/bin"
-          # In theory, this should rebuild binaries once a month
-          key: "${{ runner.os }}-cargo-binaries-${{steps.get-date.outputs.date}}"
-
-      - name: "Perform Setup"
-        run: "make setup"
-        shell: bash
-
-      - name: "Build WASM"
-        run: "make build-wasm"
-
-      - uses: "actions/upload-artifact@v2"
-        with:
-          path: js/
-          name: wasm-pkg
-
   build:
     name: "Build"
     needs: test
@@ -218,7 +163,7 @@ jobs:
       - uses: "actions/upload-artifact@v2"
         name: "Upload Rust/C Libraries"
         with:
-          path: target/libjsonlogic.*
+          path: target/release/libjsonlogic.*
           name: libs
 
       - name: "Build Python Source Dist"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,205 @@ jobs:
         env:
           WINDOWS: "${{ contains(runner.os, 'windows') }}"
           PYTHON: ${{ steps.get-py-path.outputs.path }}
+
+  build-wasm:
+    name: "Build WASM"
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the code
+      - uses: "actions/checkout@v2"
+
+      # Set the current month and year (used for cache key)
+      - name: "Get Date"
+        id: get-date
+        # Outputs e.g. "202007"
+        # tbh I have yet to find the docs where this output format is
+        # defined, but I copied this from the official cache action's README.
+        run: |
+          echo "::set-output name=date::$(/bin/date -u '+%Y%m')"
+        shell: bash
+
+      # Generate the lockfile
+      - name: "Generate Cargo Lockfile"
+        run: "cargo generate-lockfile"
+
+      # Cache build dependencies
+      - name: "Cache Build Fragments"
+        id: "cache-build-fragments"
+        uses: "actions/cache@v2"
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          # Rebuild whenever the cargo lock file changes
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache `cargo install` built binaries
+      - name: "Cache Built Binaries"
+        id: "cache-binaries"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.cargo/bin"
+          # In theory, this should rebuild binaries once a month
+          key: "${{ runner.os }}-cargo-binaries-${{steps.get-date.outputs.date}}"
+
+      - name: "Perform Setup"
+        run: "make setup"
+        shell: bash
+
+      - name: "Build WASM"
+        run: "make build-wasm"
+
+      - uses: "actions/upload-artifact@v2"
+        with:
+          path: js/
+          name: wasm-pkg
+
+  build-python-wheels:
+    name: "Build Python Wheels"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      # Check out the code
+      - uses: "actions/checkout@v2"
+
+      # Install python
+      - name: "Set up python"
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: "${{ matrix.python-version }}"
+
+      - name: "Get Python Path"
+        id: get-py-path
+        shell: bash
+        run: |
+          echo "::set-output name=path::$(which python)"
+
+      # Set the current month and year (used for cache key)
+      - name: "Get Date"
+        id: get-date
+        # Outputs e.g. "202007"
+        # tbh I have yet to find the docs where this output format is
+        # defined, but I copied this from the official cache action's README.
+        run: |
+          echo "::set-output name=date::$(/bin/date -u '+%Y%m')"
+        shell: bash
+
+      # Generate the lockfile
+      - name: "Generate Cargo Lockfile"
+        run: "cargo generate-lockfile"
+
+      # Cache build dependencies
+      - name: "Cache Build Fragments"
+        id: "cache-build-fragments"
+        uses: "actions/cache@v2"
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          # Rebuild whenever the cargo lock file changes
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache `cargo install` built binaries
+      - name: "Cache Built Binaries"
+        id: "cache-binaries"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.cargo/bin"
+          # In theory, this should rebuild binaries once a month
+          key: "${{ runner.os }}-cargo-binaries-${{steps.get-date.outputs.date}}"
+
+      - name: "Perform Setup"
+        run: "make setup"
+        shell: bash
+        env:
+          WINDOWS: "${{ contains(runner.os, 'windows') }}"
+          PYTHON: ${{ steps.get-py-path.outputs.path }}
+
+      - name: "Build Python Wheel"
+        run: "make build-py-wheel"
+        env:
+          WINDOWS: "${{ contains(runner.os, 'windows') }}"
+          PYTHON: ${{ steps.get-py-path.outputs.path }}
+
+      - uses: "actions/upload-artifact@v2"
+        with:
+          path: "dist/*.whl"
+          name: "py-${{ matrix.python-version }}-${{ runner.os }}-whl"
+
+  build-python-sdist:
+    name: "Build Python Source Dist"
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the code
+      - uses: "actions/checkout@v2"
+
+      # Install python
+      - name: "Set up python"
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: "${{ matrix.python-version }}"
+
+      - name: "Get Python Path"
+        id: get-py-path
+        shell: bash
+        run: |
+          echo "::set-output name=path::$(which python)"
+
+      # Set the current month and year (used for cache key)
+      - name: "Get Date"
+        id: get-date
+        # Outputs e.g. "202007"
+        # tbh I have yet to find the docs where this output format is
+        # defined, but I copied this from the official cache action's README.
+        run: |
+          echo "::set-output name=date::$(/bin/date -u '+%Y%m')"
+        shell: bash
+
+      # Generate the lockfile
+      - name: "Generate Cargo Lockfile"
+        run: "cargo generate-lockfile"
+
+      # Cache build dependencies
+      - name: "Cache Build Fragments"
+        id: "cache-build-fragments"
+        uses: "actions/cache@v2"
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          # Rebuild whenever the cargo lock file changes
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache `cargo install` built binaries
+      - name: "Cache Built Binaries"
+        id: "cache-binaries"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.cargo/bin"
+          # In theory, this should rebuild binaries once a month
+          key: "${{ runner.os }}-cargo-binaries-${{steps.get-date.outputs.date}}"
+
+      - name: "Perform Setup"
+        run: "make setup"
+        shell: bash
+        env:
+          WINDOWS: "${{ contains(runner.os, 'windows') }}"
+          PYTHON: ${{ steps.get-py-path.outputs.path }}
+
+      - name: "Build Python Source Dist"
+        run: "make build-py-sdist"
+        env:
+          WINDOWS: "${{ contains(runner.os, 'windows') }}"
+          PYTHON: ${{ steps.get-py-path.outputs.path }}
+
+      - uses: "actions/upload-artifact@v2"
+        with:
+          path: dist/*.tar.gz
+          name: py-sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,98 @@ jobs:
           path: js/
           name: wasm-pkg
 
+  build:
+    name: "Build"
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the code
+      - uses: "actions/checkout@v2"
+
+      # Install python
+      - name: "Set up python"
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.8"
+
+      - name: "Get Python Path"
+        id: get-py-path
+        shell: bash
+        run: |
+          echo "::set-output name=path::$(which python)"
+
+      # Set the current month and year (used for cache key)
+      - name: "Get Date"
+        id: get-date
+        # Outputs e.g. "202007"
+        # tbh I have yet to find the docs where this output format is
+        # defined, but I copied this from the official cache action's README.
+        run: |
+          echo "::set-output name=date::$(/bin/date -u '+%Y%m')"
+        shell: bash
+
+      # Generate the lockfile
+      - name: "Generate Cargo Lockfile"
+        run: "cargo generate-lockfile"
+
+      # Cache build dependencies
+      - name: "Cache Build Fragments"
+        id: "cache-build-fragments"
+        uses: "actions/cache@v2"
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          # Rebuild whenever the cargo lock file changes
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache `cargo install` built binaries
+      - name: "Cache Built Binaries"
+        id: "cache-binaries"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.cargo/bin"
+          # In theory, this should rebuild binaries once a month
+          key: "${{ runner.os }}-cargo-binaries-${{steps.get-date.outputs.date}}"
+
+      - name: "Perform Setup"
+        run: "make setup"
+        shell: bash
+        env:
+          WINDOWS: "${{ contains(runner.os, 'windows') }}"
+          PYTHON: ${{ steps.get-py-path.outputs.path }}
+
+      - name: "Build Rust/C Libraries"
+        run: "make build"
+
+      - uses: "actions/upload-artifact@v2"
+        name: "Upload Rust/C Libraries"
+        with:
+          path: target/libjsonlogic.*
+          name: libs
+
+      - name: "Build Python Source Dist"
+        run: "make build-py-sdist"
+        env:
+          WINDOWS: "${{ contains(runner.os, 'windows') }}"
+          PYTHON: ${{ steps.get-py-path.outputs.path }}
+
+      - uses: "actions/upload-artifact@v2"
+        name: "Upload Python sdist"
+        with:
+          path: dist/*.tar.gz
+          name: py-sdist
+
+      - name: "Build WASM Node Package"
+        run: "make build-wasm"
+
+      - uses: "actions/upload-artifact@v2"
+        name: "Upload node package"
+        with:
+          path: js/
+          name: wasm-pkg
+
   build-python-wheels:
     name: "Build Python Wheels"
     needs: test
@@ -226,76 +318,3 @@ jobs:
         with:
           path: "dist/*.whl"
           name: "py-${{ matrix.python-version }}-${{ runner.os }}-whl"
-
-  build-python-sdist:
-    name: "Build Python Source Dist"
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      # Check out the code
-      - uses: "actions/checkout@v2"
-
-      # Install python
-      - name: "Set up python"
-        uses: "actions/setup-python@v2"
-        with:
-          python-version: "3.8"
-
-      - name: "Get Python Path"
-        id: get-py-path
-        shell: bash
-        run: |
-          echo "::set-output name=path::$(which python)"
-
-      # Set the current month and year (used for cache key)
-      - name: "Get Date"
-        id: get-date
-        # Outputs e.g. "202007"
-        # tbh I have yet to find the docs where this output format is
-        # defined, but I copied this from the official cache action's README.
-        run: |
-          echo "::set-output name=date::$(/bin/date -u '+%Y%m')"
-        shell: bash
-
-      # Generate the lockfile
-      - name: "Generate Cargo Lockfile"
-        run: "cargo generate-lockfile"
-
-      # Cache build dependencies
-      - name: "Cache Build Fragments"
-        id: "cache-build-fragments"
-        uses: "actions/cache@v2"
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          # Rebuild whenever the cargo lock file changes
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      # Cache `cargo install` built binaries
-      - name: "Cache Built Binaries"
-        id: "cache-binaries"
-        uses: "actions/cache@v2"
-        with:
-          path: "~/.cargo/bin"
-          # In theory, this should rebuild binaries once a month
-          key: "${{ runner.os }}-cargo-binaries-${{steps.get-date.outputs.date}}"
-
-      - name: "Perform Setup"
-        run: "make setup"
-        shell: bash
-        env:
-          WINDOWS: "${{ contains(runner.os, 'windows') }}"
-          PYTHON: ${{ steps.get-py-path.outputs.path }}
-
-      - name: "Build Python Source Dist"
-        run: "make build-py-sdist"
-        env:
-          WINDOWS: "${{ contains(runner.os, 'windows') }}"
-          PYTHON: ${{ steps.get-py-path.outputs.path }}
-
-      - uses: "actions/upload-artifact@v2"
-        with:
-          path: dist/*.tar.gz
-          name: py-sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,10 @@ jobs:
           PYTHON: ${{ steps.get-py-path.outputs.path }}
 
   build:
-    name: "Build"
+    name: "Build Libs, WASM, and Python sdist"
     needs: test
     runs-on: ubuntu-latest
+    if: "${{ github.ref == 'master' }}"
     steps:
       # Check out the code
       - uses: "actions/checkout@v2"
@@ -190,6 +191,7 @@ jobs:
   build-python-wheels:
     name: "Build Python Wheels"
     needs: test
+    if: "${{ github.ref == 'master' }}"
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
       - name: "Set up python"
         uses: "actions/setup-python@v2"
         with:
-          python-version: "${{ matrix.python-version }}"
+          python-version: "3.8"
 
       - name: "Get Python Path"
         id: get-py-path

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # json-logic-rs
 
+![Continuous Integration](https://github.com/Bestowinc/json-logic-rs/workflows/Continuous%20Integration/badge.svg?branch=master)
+
 This s an implementation of  the [JSONLogic] specification in Rust.
 
 ## Building


### PR DESCRIPTION
Add build steps and artifact uploads for rust/c libraries, python wheels for [linux, mac, windows] * [py36, py37, py38], a python source distribution, and a node package for the WASM.

Storing the artifacts lets us introspect them later, and of course we can use them in a subsequent publish step. Note that the most recent commit gates the builds on merge to master, but if you look at the CI from previous commits, you can see that the building and uploading is working as intended.

Note that as far as I can tell the duplication in the workflow file is unavoidable. You need to include the cache directives in each job for them to make use of the cache, and YAML anchors are not supported.