### PR TITLE
MAINT: build manylinux wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         # python integration tests
         run: |
           cargo test --features=wasm
-          make build-py-wheel
+          make develop-py-wheel
           ls dist/*.whl
           pip install dist/*.whl
           echo "Running Tests"
@@ -194,8 +194,8 @@ jobs:
     # Linux wheels can't be built directly but instead need to be built
     # via a "manylinux" container as specified by PEPs 513, 571, and 599
     name: "Build Linux Wheels"
-    # needs: "test"
-    # if: "${{ github.ref == 'master' }}"
+    needs: "test"
+    if: "${{ github.ref == 'master' }}"
     runs-on: "ubuntu-latest"
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,13 +188,85 @@ jobs:
           path: js/
           name: wasm-pkg
 
-  build-python-wheels:
-    name: "Build Python Wheels"
+  build-python-wheels-linux:
+    # Linux wheels can't be built directly but instead need to be built
+    # via a "manylinux" container as specified by PEPs 513, 571, and 599
+    name: "Build Linux Wheels"
+    needs: "test"
+    if: "${{ github.ref == 'master' }}"
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        manylinux:
+          - arch: "manylinux1_i686"
+            img: "quay.io/pypa/manylinux1_i686:2020-07-04-283458f"
+          - arch: "manylinux1_x86_64"
+            img: "quay.io/pypa/manylinux1_x86_64:2020-07-04-10a3c30"
+          - arch: "manylinux2010_i686"
+            img: "quay.io/pypa/manylinux2010_i686:2020-07-04-10a3c30"
+          - arch: "manylinux2010_x86_64"
+            img: "quay.io/pypa/manylinux2010_x86_64:2020-07-04-10a3c30"
+          - arch: "manylinux2014_aarch64"
+            img: "quay.io/pypa/manylinux2014_aarch64:2020-07-04-bb5f087"
+          - arch: "manylinux2014_i686"
+            img: "quay.io/pypa/manylinux2014_i686:2020-07-04-bb5f087"
+          - arch: "manylinux2014_x86_64"
+            img: "quay.io/pypa/manylinux2014_x86_64:2020-07-04-bb5f087"
+    steps:
+      # Check out the code
+      - uses: "actions/checkout@v2"
+      # Set the current month and year (used for cache key)
+      - name: "Get Date"
+        id: get-date
+        # Outputs e.g. "202007"
+        # tbh I have yet to find the docs where this output format is
+        # defined, but I copied this from the official cache action's README.
+        run: |
+          echo "::set-output name=date::$(/bin/date -u '+%Y%m')"
+        shell: bash
+
+      # Generate the lockfile
+      - name: "Generate Cargo Lockfile"
+        run: "cargo generate-lockfile"
+
+      # Cache build dependencies
+      - name: "Cache Build Fragments"
+        id: "cache-build-fragments"
+        uses: "actions/cache@v2"
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          # Rebuild whenever the cargo lock file changes
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache `cargo install` built binaries
+      - name: "Cache Built Binaries"
+        id: "cache-binaries"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.cargo/bin"
+          # In theory, this should rebuild binaries once a month
+          key: "${{ runner.os }}-cargo-binaries-${{steps.get-date.outputs.date}}"
+
+      - name: "Build Wheels"
+        run: "make build-py-wheel-manylinux"
+        env:
+          MANYLINUX_IMG: ${{ matrix.manylinux.img }}
+
+      - uses: "actions/upload-artifact@v2"
+        with:
+          path: "dist/*.whl"
+          name: "py-${{ matrix.manylinux.arch }}-wheels"
+
+  build-python-wheels-mac-windows:
+    name: "Build Python Wheels (MacOS, Windows)"
     needs: test
     if: "${{ github.ref == 'master' }}"
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
     runs-on: "${{ matrix.os }}"
     steps:
@@ -264,4 +336,4 @@ jobs:
       - uses: "actions/upload-artifact@v2"
         with:
           path: "dist/*.whl"
-          name: "py-${{ matrix.python-version }}-${{ runner.os }}-whl"
+          name: "py-${{ matrix.python-version }}-${{ runner.os }}-wheels"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,8 @@ jobs:
         # python integration tests
         run: |
           cargo test --features=wasm
-          rm -rf dist/*
-          rm -rf build/*
-          make develop-py-wheel
+          make build-py-wheel
+          ls dist/*.whl
           pip install dist/*.whl
           echo "Running Tests"
           python tests/test_py.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,8 @@ jobs:
     # Linux wheels can't be built directly but instead need to be built
     # via a "manylinux" container as specified by PEPs 513, 571, and 599
     name: "Build Linux Wheels"
-    needs: "test"
-    if: "${{ github.ref == 'master' }}"
+    # needs: "test"
+    # if: "${{ github.ref == 'master' }}"
     runs-on: "ubuntu-latest"
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             ~/.cargo/git
             target
           # Rebuild whenever the cargo lock file changes
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-v2
 
       # Cache `cargo install` built binaries
       - name: "Cache Built Binaries"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          # Rebuild whenever the cargo lock file changes
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-v2
+          # Use the OS, the python version, and the hashed cargo lockfile as the
+          # cache key. The Python version shouldn't be necessary, but I have
+          # seen some weird failures in Windows CI where it gets the built
+          # python targets confused. The Python version is included at the
+          # end so it can be partially matched by cache keys in contexts
+          # where we're not iterating over python envs.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}
 
       # Cache `cargo install` built binaries
       - name: "Cache Built Binaries"
@@ -141,7 +146,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          # Rebuild whenever the cargo lock file changes
+          # This should partial match the caches generated for the tests,
+          # which include a python version at the end.
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       # Cache `cargo install` built binaries
@@ -238,7 +244,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          # Rebuild whenever the cargo lock file changes
+          # This should partial match the caches generated for the tests,
+          # which include a python version at the end.
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       # Cache `cargo install` built binaries
@@ -308,8 +315,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          # Rebuild whenever the cargo lock file changes
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # Use the OS, the python version, and the hashed cargo lockfile as the
+          # cache key. The Python version shouldn't be necessary, but I have
+          # seen some weird failures in Windows CI where it gets the built
+          # python targets confused. The Python version is included at the
+          # end so it can be partially matched by cache keys in contexts
+          # where we're not iterating over python envs.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}
 
       # Cache `cargo install` built binaries
       - name: "Cache Built Binaries"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           - arch: "manylinux1_i686"
             img: "quay.io/pypa/manylinux1_i686:2020-07-04-283458f"
           - arch: "manylinux1_x86_64"
-            img: "quay.io/pypa/manylinux1_x86_64:2020-07-04-10a3c30"
+            img: "quay.io/pypa/manylinux1_x86_64:2020-07-04-283458f"
           - arch: "manylinux2010_i686"
             img: "quay.io/pypa/manylinux2010_i686:2020-07-04-10a3c30"
           - arch: "manylinux2010_x86_64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,8 +206,6 @@ jobs:
             img: "quay.io/pypa/manylinux2010_i686:2020-07-04-10a3c30"
           - arch: "manylinux2010_x86_64"
             img: "quay.io/pypa/manylinux2010_x86_64:2020-07-04-10a3c30"
-          - arch: "manylinux2014_aarch64"
-            img: "quay.io/pypa/manylinux2014_aarch64:2020-07-04-bb5f087"
           - arch: "manylinux2014_i686"
             img: "quay.io/pypa/manylinux2014_i686:2020-07-04-bb5f087"
           - arch: "manylinux2014_x86_64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,11 @@ jobs:
         # python integration tests
         run: |
           cargo test --features=wasm
+          rm -rf dist/*
+          rm -rf build/*
           make develop-py-wheel
           pip install dist/*.whl
+          echo "Running Tests"
           python tests/test_py.py
         env:
           WINDOWS: "${{ contains(runner.os, 'windows') }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
+# cdylib for CFFI and python integration
+# lib for regular rust stuff
 crate-type = ["cdylib", "lib"]
 
 [features]

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ debug-wasm:
 .PHONY: build-py-sdist
 build-py-sdist: $(VENV)
 	cargo clean -p jsonlogic
+	rm -rf dist/*
 	$(VENV) setup.py sdist
 
 .PHONY: build-py-wheel
@@ -37,6 +38,19 @@ build-py-wheel: $(VENV)
 	rm -rf dist/*
 	$(VENV) setup.py bdist_wheel
 
+# NOTE: this command may sudo on linux
+.PHONY: build-py-wheel-manylinux
+build-py-wheel-manylinux:
+	rm -rf build/*
+	rm -rf dist/*
+	docker run -v "$$PWD":/io --rm $(MANYLINUX_IMG) /io/build-wheels.sh
+
+.PHONY: build-py-all
+build-py-all: $(VENV)
+	cargo clean -p jsonlogic
+	rm -rf dist/*
+	$(VENV) setup.py sdist bdist_wheel
+
 .PHONY: develop-py-wheel
 develop-py-wheel: $(VENV)
 	$(VENV) setup.py bdist_wheel
@@ -44,6 +58,16 @@ develop-py-wheel: $(VENV)
 .PHONY: develop-py
 develop-py: $(VENV)
 	$(VENV) setup.py develop
+
+.PHONY: distribute-py
+distribute-py: $(VENV)
+	$(VENV) -m pip install twine
+	twine upload -s dist/*
+
+.PHONY: test-distribute-py
+test-distribute-py:
+	$(VENV) -m pip install twine
+	twine upload -s --repository testpypi dist/*
 
 .PHONY: setup
 setup:

--- a/Makefile
+++ b/Makefile
@@ -26,29 +26,29 @@ build-wasm: setup
 debug-wasm:
 	rm -rf ./js && wasm-pack build --target nodejs --out-dir js --out-name index --debug -- --features wasm
 
-.PHONY: build-py-sdist
-build-py-sdist: $(VENV)
-	cargo clean -p jsonlogic
+.PHONY: clean-py
+clean-py:
+	rm -rf build/*
 	rm -rf dist/*
+
+.PHONY: build-py-sdist
+build-py-sdist: $(VENV) clean-py
+	cargo clean -p jsonlogic
 	$(VENV) setup.py sdist
 
 .PHONY: build-py-wheel
-build-py-wheel: $(VENV)
+build-py-wheel: $(VENV) clean-py
 	cargo clean -p jsonlogic
-	rm -rf dist/*
 	$(VENV) setup.py bdist_wheel
 
 # NOTE: this command may sudo on linux
 .PHONY: build-py-wheel-manylinux
-build-py-wheel-manylinux:
-	rm -rf build/*
-	rm -rf dist/*
+build-py-wheel-manylinux: clean-py
 	docker run -v "$$PWD":/io --rm $(MANYLINUX_IMG) /io/build-wheels.sh
 
 .PHONY: build-py-all
-build-py-all: $(VENV)
+build-py-all: $(VENV) clean-py
 	cargo clean -p jsonlogic
-	rm -rf dist/*
 	$(VENV) setup.py sdist bdist_wheel
 
 .PHONY: develop-py-wheel

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Expected to be run in a manylinux container
+
+set -ex
+
+cd /io
+
+curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain stable -y
+
+export PATH=/root/.cargo/bin:$PATH
+
+mkdir -p build && rm -rf build/*
+
+for PYBIN in /opt/python/{cp36-cp36m,cp37-cp37m,cp38-cp38}/bin; do
+    export PYTHON_SYS_EXECUTABLE="$PYBIN/python"
+
+    "${PYBIN}/python" -m ensurepip
+    "${PYBIN}/python" -m pip install -U setuptools wheel setuptools-rust
+    "${PYBIN}/python" setup.py bdist_wheel
+done
+
+for whl in dist/*.whl; do
+    auditwheel repair "$whl" -w dist/
+done

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ EMAIL = "msplanchard@gmail.com"
 
 def get_version():
     proc = Popen(("cargo", "pkgid"), stdout=PIPE, stderr=PIPE)
-    out, _err = tuple(map(bytes.decode, proc.communicate()))
+    out, err = tuple(map(bytes.decode, proc.communicate()))
     if proc.returncode != 0:
-        raise RuntimeError("Could not get Cargo package info")
+        raise RuntimeError(f"Could not get Cargo package info: {err}")
     version = out.split(":")[-1]
     return version.strip()
 

--- a/tests/test_py.rs
+++ b/tests/test_py.rs
@@ -6,10 +6,6 @@
 //! as a runner.
 
 #[cfg(feature = "python")]
-use std::fs;
-#[cfg(feature = "python")]
-use std::path;
-#[cfg(feature = "python")]
 use std::process::Command;
 
 #[cfg(feature = "python")]


### PR DESCRIPTION
Unlike Mac and Windows, wheels built on a given linux system are not necessary cross-distro compatible, even on the same architecture. There is a standard called [manylinux](https://github.com/pypa/manylinux) for building cross-distro wheels, defined in PEPs 513, 571, and 599. The manylinux project provides the `auditwheel` program (used in the `build-wheels.sh` script in this PR), which takes a regular linux wheel and turns it into a manylinux wheel, provided it was originally built linking to particular versions of libraries. Docker containers are provided that have those libraries available for linking, so we're using those docker containers in our build.

This adds a new build job to build manylinux wheels for each python and for a variety of architectures.

While I was testing, I set the wheel building job to run concurrently with tests. This caused some issues with caching to come to the forefront (with windows, naturally), so this also adjusts the cache keys to be python-version specific.