### PR TITLE
FIX: Make checkNewCargoVersion.sh windows-compatible; fix secret injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,8 +491,8 @@ jobs:
 
   distribute-py-wheels-mac-windows:
     name: "Distribute Mac and Windows Python Wheels"
-    needs: "build-python-wheels-mac-windows"
-    if: "${{ github.ref == 'refs/heads/master' }}"
+    # needs: "build-python-wheels-mac-windows"
+    # if: "${{ github.ref == 'refs/heads/master' }}"
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
@@ -542,15 +542,15 @@ jobs:
           name: "py-${{ matrix.python-version }}-${{ runner.os }}-wheels"
           path: dist-py
 
-      - name: "Publish Wheels"
-        shell: bash
-        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-        run: |
-          pip install twine
-          twine upload --skip-existing dist-py/*
-        env:
-          TWINE_USERNAME: "__token__"
-          TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
+      # - name: "Publish Wheels"
+      #   shell: bash
+      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+      #   run: |
+      #     pip install twine
+      #     twine upload --skip-existing dist-py/*
+      #   env:
+      #     TWINE_USERNAME: "__token__"
+      #     TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
 
   distribute-py-wheels-linux:
     name: "Distribute Linux Python Wheels"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,9 +356,9 @@ jobs:
 
   distribute:
     name: "Distribute Cargo, WASM, and Python Sdist Packages"
-    needs: "build"
+    # needs: "build"
     runs-on: ubuntu-latest
-    if: "${{ github.ref == 'refs/heads/master' }}"
+    # if: "${{ github.ref == 'refs/heads/master' }}"
     steps:
       # Check out the code
       - uses: "actions/checkout@v2"
@@ -390,7 +390,7 @@ jobs:
         id: get-version
         shell: bash
         run: |
-          echo "::set-output name=version::$(cargo pkgid | tr ':' ' ' | awk '{print $3}')"
+          echo "::set-output name=version::$(cargo pkgid | tr '#' '\n' | tail -n 1 | tr ':' ' ' | awk '{print $2}')"
 
       - name: "(DEBUG) log current version"
         shell: bash
@@ -403,42 +403,42 @@ jobs:
         run: |
           echo "::set-output name=new::$(./scripts/newCargoVersion.sh)"
 
-      - name: "Add Git Tag Ref for Version"
-        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-        uses: "actions/github-script@v2"
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          script: |
-            github.git.createRef({
-              owner: "${{ github.repository_owner }}",
-              repo: "${{ github.repository }}",
-              ref: "refs/tags/v${{ steps.get-version.ouputs.version }}",
-              sha: "${{ github.sha }}",
-            })
+      # - name: "Add Git Tag Ref for Version"
+      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+      #   uses: "actions/github-script@v2"
+      #   with:
+      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
+      #     script: |
+      #       github.git.createRef({
+      #         owner: "${{ github.repository_owner }}",
+      #         repo: "${{ github.repository }}",
+      #         ref: "refs/tags/v${{ steps.get-version.ouputs.version }}",
+      #         sha: "${{ github.sha }}",
+      #       })
 
-      - name: "Add GitHub Annotated Tag for Version"
-        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-        uses: "actions/github-script@v2"
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          script: |
-            github.git.createTag({
-              owner: "${{ github.repository_owner }}",
-              repo: "${{ github.repository }}",
-              tag: "v${{ steps.get-version.ouputs.version }}",
-              message: "Vesrion ${{ steps.get-version.outputs.version }}",
-              object: "${{ github.sha }}",
-              type: "commit",
-              tagger: {
-                name: "${{ github.actor }}",
-              }
-            })
+      # - name: "Add GitHub Annotated Tag for Version"
+      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+      #   uses: "actions/github-script@v2"
+      #   with:
+      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
+      #     script: |
+      #       github.git.createTag({
+      #         owner: "${{ github.repository_owner }}",
+      #         repo: "${{ github.repository }}",
+      #         tag: "v${{ steps.get-version.ouputs.version }}",
+      #         message: "Vesrion ${{ steps.get-version.outputs.version }}",
+      #         object: "${{ github.sha }}",
+      #         type: "commit",
+      #         tagger: {
+      #           name: "${{ github.actor }}",
+      #         }
+      #       })
 
-      - name: "Check if new NPM version"
-        id: npm-version
-        shell: bash
-        run: |
-          echo "::set-output name=new::$(./scripts/newNpmVersion.sh)"
+      # - name: "Check if new NPM version"
+      #   id: npm-version
+      #   shell: bash
+      #   run: |
+      #     echo "::set-output name=new::$(./scripts/newNpmVersion.sh)"
 
       # Note we don't check for a new python version b/c there are so
       # many python artifacts that it is impractical. Instead we just
@@ -451,44 +451,44 @@ jobs:
           echo "Cargo: ${{ steps.cargo-version.outputs.new }}"
           echo "NPM: ${{ steps.npm-version.outputs.new }}"
 
-      - name: "Cargo Publish"
-        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-        run: |
-          cargo publish --token "$CARGO_TOKEN"
-        env:
-          CARGO_TOKEN: "${{ secrets.CARGO_TOKEN }}"
+      # - name: "Cargo Publish"
+      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+      #   run: |
+      #     cargo publish --token "$CARGO_TOKEN"
+      #   env:
+      #     CARGO_TOKEN: "${{ secrets.CARGO_TOKEN }}"
 
-      - name: "Pull WASM Artifact"
-        uses: "actions/download-artifact@v1"
-        if: "${{ steps.npm-version.outputs.new == 'true' }}"
-        with:
-          name: wasm-pkg
-          path: dist-wasm
+      # - name: "Pull WASM Artifact"
+      #   uses: "actions/download-artifact@v1"
+      #   if: "${{ steps.npm-version.outputs.new == 'true' }}"
+      #   with:
+      #     name: wasm-pkg
+      #     path: dist-wasm
 
-      - name: "Publish NPM Package"
-        shell: bash
-        if: "${{ steps.npm-version.outputs.new == 'true' }}"
-        run: |
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-          npm publish dist-wasm/ --access public
-        env:
-          NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
+      # - name: "Publish NPM Package"
+      #   shell: bash
+      #   if: "${{ steps.npm-version.outputs.new == 'true' }}"
+      #   run: |
+      #     echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      #     npm publish dist-wasm/ --access public
+      #   env:
+      #     NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
 
-      - name: "Pull Python Sdist Artifact"
-        uses: "actions/download-artifact@v1"
-        with:
-          name: py-sdist
-          path: dist-py
+      # - name: "Pull Python Sdist Artifact"
+      #   uses: "actions/download-artifact@v1"
+      #   with:
+      #     name: py-sdist
+      #     path: dist-py
 
-      - name: "Publish Python Sdist"
-        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-        shell: bash
-        run: |
-          pip install twine
-          twine upload --skip-existing dist-py/*
-        env:
-          TWINE_USERNAME: "__token__"
-          TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
+      # - name: "Publish Python Sdist"
+      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+      #   shell: bash
+      #   run: |
+      #     pip install twine
+      #     twine upload --skip-existing dist-py/*
+      #   env:
+      #     TWINE_USERNAME: "__token__"
+      #     TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
 
   distribute-py-wheels-mac-windows:
     name: "Distribute Mac and Windows Python Wheels"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,7 +453,9 @@ jobs:
       - name: "Cargo Publish"
         if: "${{ steps.cargo-version.outputs.new == 'true' }}"
         run: |
-          cargo publish --token "${{ secrets.CARGO_TOKEN }}"
+          cargo publish --token "$CARGO_TOKEN"
+        env:
+          CARGO_TOKEN: "${{ secrets.CARGO_TOKEN }}"
 
       - name: "Pull WASM Artifact"
         uses: "actions/download-artifact@v1"
@@ -466,8 +468,10 @@ jobs:
         shell: bash
         if: "${{ steps.npm-version.outputs.new == 'true' }}"
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
           npm publish dist-wasm/ --access public
+        env:
+          NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
 
       - name: "Pull Python Sdist Artifact"
         uses: "actions/download-artifact@v1"
@@ -480,7 +484,10 @@ jobs:
         shell: bash
         run: |
           pip install twine
-          twine upload -u "__token__" -p "${{ secrets.PYPI_TOKEN }}" --skip-existing dist-py/*
+          twine upload --skip-existing dist-py/*
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
 
   distribute-py-wheels-mac-windows:
     name: "Distribute Mac and Windows Python Wheels"
@@ -511,6 +518,11 @@ jobs:
         run: |
           echo "::set-output name=new::$(./scripts/newCargoVersion.sh)"
 
+      - name: "(DEBUG) is new cargo version"
+        shell: bash
+        run: |
+          echo "${{ steps.cargo-version.outputs.new }}"
+
       # Cache build dependencies
       - name: "Cache Build Fragments"
         id: "cache-build-fragments"
@@ -535,7 +547,10 @@ jobs:
         if: "${{ steps.cargo-version.outputs.new == 'true' }}"
         run: |
           pip install twine
-          twine upload -u "__token__" -p "${{ secrets.PYPI_TOKEN }}" --skip-existing dist-py/*
+          twine upload --skip-existing dist-py/*
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
 
   distribute-py-wheels-linux:
     name: "Distribute Linux Python Wheels"
@@ -571,6 +586,11 @@ jobs:
         run: |
           echo "::set-output name=new::$(./scripts/newCargoVersion.sh)"
 
+      - name: "(DEBUG) is new cargo version"
+        shell: bash
+        run: |
+          echo "${{ steps.cargo-version.outputs.new }}"
+
       # Cache build dependencies
       - name: "Cache Build Fragments"
         id: "cache-build-fragments"
@@ -595,4 +615,7 @@ jobs:
         shell: bash
         run: |
           pip install twine
-          twine upload -u "__token__" -p "${{ secrets.PYPI_TOKEN }}" --skip-existing dist-py/*
+          twine upload --skip-existing dist-py/*
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,11 +536,11 @@ jobs:
           # which include a python version at the end.
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: "Pull Python Wheels"
-        uses: "actions/download-artifact@v1"
-        with:
-          name: "py-${{ matrix.python-version }}-${{ runner.os }}-wheels"
-          path: dist-py
+      # - name: "Pull Python Wheels"
+      #   uses: "actions/download-artifact@v1"
+      #   with:
+      #     name: "py-${{ matrix.python-version }}-${{ runner.os }}-wheels"
+      #     path: dist-py
 
       # - name: "Publish Wheels"
       #   shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push]
 jobs:
   test:
     name: "Test"
+    if: false
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on: [push]
 jobs:
   test:
     name: "Test"
-    if: false
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -356,9 +355,9 @@ jobs:
 
   distribute:
     name: "Distribute Cargo, WASM, and Python Sdist Packages"
-    # needs: "build"
+    needs: "build"
     runs-on: ubuntu-latest
-    # if: "${{ github.ref == 'refs/heads/master' }}"
+    if: "${{ github.ref == 'refs/heads/master' }}"
     steps:
       # Check out the code
       - uses: "actions/checkout@v2"
@@ -403,42 +402,42 @@ jobs:
         run: |
           echo "::set-output name=new::$(./scripts/newCargoVersion.sh)"
 
-      # - name: "Add Git Tag Ref for Version"
-      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-      #   uses: "actions/github-script@v2"
-      #   with:
-      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
-      #     script: |
-      #       github.git.createRef({
-      #         owner: "${{ github.repository_owner }}",
-      #         repo: "${{ github.repository }}",
-      #         ref: "refs/tags/v${{ steps.get-version.ouputs.version }}",
-      #         sha: "${{ github.sha }}",
-      #       })
+      - name: "Add Git Tag Ref for Version"
+        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+        uses: "actions/github-script@v2"
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            github.git.createRef({
+              owner: "${{ github.repository_owner }}",
+              repo: "${{ github.repository }}",
+              ref: "refs/tags/v${{ steps.get-version.ouputs.version }}",
+              sha: "${{ github.sha }}",
+            })
 
-      # - name: "Add GitHub Annotated Tag for Version"
-      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-      #   uses: "actions/github-script@v2"
-      #   with:
-      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
-      #     script: |
-      #       github.git.createTag({
-      #         owner: "${{ github.repository_owner }}",
-      #         repo: "${{ github.repository }}",
-      #         tag: "v${{ steps.get-version.ouputs.version }}",
-      #         message: "Vesrion ${{ steps.get-version.outputs.version }}",
-      #         object: "${{ github.sha }}",
-      #         type: "commit",
-      #         tagger: {
-      #           name: "${{ github.actor }}",
-      #         }
-      #       })
+      - name: "Add GitHub Annotated Tag for Version"
+        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+        uses: "actions/github-script@v2"
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            github.git.createTag({
+              owner: "${{ github.repository_owner }}",
+              repo: "${{ github.repository }}",
+              tag: "v${{ steps.get-version.ouputs.version }}",
+              message: "Vesrion ${{ steps.get-version.outputs.version }}",
+              object: "${{ github.sha }}",
+              type: "commit",
+              tagger: {
+                name: "${{ github.actor }}",
+              }
+            })
 
-      # - name: "Check if new NPM version"
-      #   id: npm-version
-      #   shell: bash
-      #   run: |
-      #     echo "::set-output name=new::$(./scripts/newNpmVersion.sh)"
+      - name: "Check if new NPM version"
+        id: npm-version
+        shell: bash
+        run: |
+          echo "::set-output name=new::$(./scripts/newNpmVersion.sh)"
 
       # Note we don't check for a new python version b/c there are so
       # many python artifacts that it is impractical. Instead we just
@@ -451,49 +450,49 @@ jobs:
           echo "Cargo: ${{ steps.cargo-version.outputs.new }}"
           echo "NPM: ${{ steps.npm-version.outputs.new }}"
 
-      # - name: "Cargo Publish"
-      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-      #   run: |
-      #     cargo publish --token "$CARGO_TOKEN"
-      #   env:
-      #     CARGO_TOKEN: "${{ secrets.CARGO_TOKEN }}"
+      - name: "Cargo Publish"
+        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+        run: |
+          cargo publish --token "$CARGO_TOKEN"
+        env:
+          CARGO_TOKEN: "${{ secrets.CARGO_TOKEN }}"
 
-      # - name: "Pull WASM Artifact"
-      #   uses: "actions/download-artifact@v1"
-      #   if: "${{ steps.npm-version.outputs.new == 'true' }}"
-      #   with:
-      #     name: wasm-pkg
-      #     path: dist-wasm
+      - name: "Pull WASM Artifact"
+        uses: "actions/download-artifact@v1"
+        if: "${{ steps.npm-version.outputs.new == 'true' }}"
+        with:
+          name: wasm-pkg
+          path: dist-wasm
 
-      # - name: "Publish NPM Package"
-      #   shell: bash
-      #   if: "${{ steps.npm-version.outputs.new == 'true' }}"
-      #   run: |
-      #     echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-      #     npm publish dist-wasm/ --access public
-      #   env:
-      #     NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
+      - name: "Publish NPM Package"
+        shell: bash
+        if: "${{ steps.npm-version.outputs.new == 'true' }}"
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+          npm publish dist-wasm/ --access public
+        env:
+          NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
 
-      # - name: "Pull Python Sdist Artifact"
-      #   uses: "actions/download-artifact@v1"
-      #   with:
-      #     name: py-sdist
-      #     path: dist-py
+      - name: "Pull Python Sdist Artifact"
+        uses: "actions/download-artifact@v1"
+        with:
+          name: py-sdist
+          path: dist-py
 
-      # - name: "Publish Python Sdist"
-      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-      #   shell: bash
-      #   run: |
-      #     pip install twine
-      #     twine upload --skip-existing dist-py/*
-      #   env:
-      #     TWINE_USERNAME: "__token__"
-      #     TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
+      - name: "Publish Python Sdist"
+        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+        shell: bash
+        run: |
+          pip install twine
+          twine upload --skip-existing dist-py/*
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
 
   distribute-py-wheels-mac-windows:
     name: "Distribute Mac and Windows Python Wheels"
-    # needs: "build-python-wheels-mac-windows"
-    # if: "${{ github.ref == 'refs/heads/master' }}"
+    needs: "build-python-wheels-mac-windows"
+    if: "${{ github.ref == 'refs/heads/master' }}"
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
@@ -537,21 +536,21 @@ jobs:
           # which include a python version at the end.
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      # - name: "Pull Python Wheels"
-      #   uses: "actions/download-artifact@v1"
-      #   with:
-      #     name: "py-${{ matrix.python-version }}-${{ runner.os }}-wheels"
-      #     path: dist-py
+      - name: "Pull Python Wheels"
+        uses: "actions/download-artifact@v1"
+        with:
+          name: "py-${{ matrix.python-version }}-${{ runner.os }}-wheels"
+          path: dist-py
 
-      # - name: "Publish Wheels"
-      #   shell: bash
-      #   if: "${{ steps.cargo-version.outputs.new == 'true' }}"
-      #   run: |
-      #     pip install twine
-      #     twine upload --skip-existing dist-py/*
-      #   env:
-      #     TWINE_USERNAME: "__token__"
-      #     TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
+      - name: "Publish Wheels"
+        shell: bash
+        if: "${{ steps.cargo-version.outputs.new == 'true' }}"
+        run: |
+          pip install twine
+          twine upload --skip-existing dist-py/*
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"
 
   distribute-py-wheels-linux:
     name: "Distribute Linux Python Wheels"

--- a/scripts/newCargoVersion.sh
+++ b/scripts/newCargoVersion.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env sh
-set -eux
+#!/usr/bin/env bash
+set -euo pipefail
 
-CURRENT_VERSION=$(cargo pkgid | tr ':' ' ' | awk '{print $3}')
+CURRENT_VERSION=$(cargo pkgid | tr '#' '\n' | tail -n 1 | tr ':' ' ' | awk '{print $2}')
 
 RESP=$(curl 'https://crates.io/api/v1/crates/jsonlogic-rs' -s \
     -H 'User-Agent: mplanchard_verison_check (msplanchard@gmail.com)' \
@@ -15,7 +15,7 @@ PREV_VERSION=$(echo "${RESP}" \
     | awk '{print $2}' \
     | sed 's/"//g')
 
-if [ "${CURRENT_VERSION}" = "${PREV_VERSION}" ]; then
+if [[ "${CURRENT_VERSION}" == "${PREV_VERSION}" ]]; then
     echo false
     exit 0
 else

--- a/scripts/newCargoVersion.sh
+++ b/scripts/newCargoVersion.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 CURRENT_VERSION=$(cargo pkgid | tr ':' ' ' | awk '{print $3}')
 
@@ -15,7 +15,7 @@ PREV_VERSION=$(echo "${RESP}" \
     | awk '{print $2}' \
     | sed 's/"//g')
 
-if [[ "${CURRENT_VERSION}" == "${PREV_VERSION}" ]]; then
+if [ "${CURRENT_VERSION}" = "${PREV_VERSION}" ]; then
     echo false
     exit 0
 else

--- a/scripts/newCargoVersion.sh
+++ b/scripts/newCargoVersion.sh
@@ -3,9 +3,17 @@ set -euo pipefail
 
 CURRENT_VERSION=$(cargo pkgid | tr ':' ' ' | awk '{print $3}')
 
-RESP=$(curl 'https://crates.io/api/v1/crates/jsonlogic-rs' -H 'User-Agent: mplanchard_verison_check (msplanchard@gmail.com)' -H 'Accept: application/json' -H 'Cache-Control: max-age=0' -s)
+RESP=$(curl 'https://crates.io/api/v1/crates/jsonlogic-rs' -s \
+    -H 'User-Agent: mplanchard_verison_check (msplanchard@gmail.com)' \
+    -H 'Accept: application/json' \
+    -H 'Cache-Control: max-age=0')
 
-PREV_VERSION=$(echo "${RESP}" | tr ',' '\n' | grep newest_version | tr ':' ' ' | awk '{print $2}' | sed 's/"//g')
+PREV_VERSION=$(echo "${RESP}" \
+    | tr ',' '\n' \
+    | grep newest_version \
+    | tr ':' ' ' \
+    | awk '{print $2}' \
+    | sed 's/"//g')
 
 if [[ "${CURRENT_VERSION}" == "${PREV_VERSION}" ]]; then
     echo false

--- a/scripts/newCargoVersion.sh
+++ b/scripts/newCargoVersion.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -eu
+set -eux
 
 CURRENT_VERSION=$(cargo pkgid | tr ':' ' ' | awk '{print $3}')
 


### PR DESCRIPTION
The way we were doing the version check for `checkNewCargoVersion.sh` was failing on Windows due to windows paths having more `:`'s in them, I think.

In addition, I realized you have to pass secrets in as env vars, so this sets that up.