### PR TITLE
MAINT: Bump version to 0.1.1 to test release cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1] - 2020-07-14
 
+### Fixed
+- The Python source dist wasn't generating a lockfile prior to attempting to
+  determine the package version, causing the `cargo pkgid` command to fail
+- The Python source dist wasn't generating a Cargo lockfile prior to attempting 
+  to determine the package version, causing the `cargo pkgid` command to fail
+
 ### Chore
 - CI fixes for distribution of all the python wheels
 - Bumped version to test distribution pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2020-07-14
 
 ### Fixed
-- The Python source dist wasn't generating a lockfile prior to attempting to
-  determine the package version, causing the `cargo pkgid` command to fail
 - The Python source dist wasn't generating a Cargo lockfile prior to attempting 
   to determine the package version, causing the `cargo pkgid` command to fail
 
 ### Chore
 - CI fixes for distribution of all the python wheels
 - Bumped version to test distribution pipeline
+
+### Docs
+- Installation instructions in README
 
 ## [0.1.0] - 2020-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - 2020-07-14
+
+### Chore
+- CI fixes for distribution of all the python wheels
+- Bumped version to test distribution pipeline
+
+## [0.1.0] - 2020-07-05
+
+### Added
+- All standard JSONLogic operations
+- WASM build
+- Python SDist build
+- Packages published & registered on the various package repositories
+
+[Unreleased]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Bestowinc/json-logic-rs/compare/0ce0196...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "jsonlogic-rs"
 readme = "README.md"
 repository = "https://github.com/bestowinc/json-logic-rs"
-version = "0.1.0"
+version = "0.1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Continuous Integration](https://github.com/Bestowinc/json-logic-rs/workflows/Continuous%20Integration/badge.svg?branch=master)
 
-This is an implementation of  the [JSONLogic] specification in Rust.
+This is an implementation of  the [JsonLogic] specification in Rust.
 
 ## Project Status
 
@@ -12,11 +12,11 @@ We also implement the `?:`, which is not described in that specification
 but is a direct alias for `if`.
 
 All operations are tested using our own test suite in Rust as well as the
-shared tests for all jsonlogic implementations defined [here](http://jsonlogic.com/tests.json).
+shared tests for all JsonLogic implementations defined [here](http://jsonlogic.com/tests.json).
 
 We are working on adding new operations with improved type safety, as well
-as the ability to define functions as jsonlogic. We will communicate with
-the broader jsonlogic community to see if we can make them part of the
+as the ability to define functions as JsonLogic. We will communicate with
+the broader JsonLogic community to see if we can make them part of the
 standard as we do so.
 
 Being built in Rust, we are able to provide the package in a variety of
@@ -28,6 +28,43 @@ languages. The table below describes current language support:
 | JavaScript (as WASM) | Node Package via [NPM](https://www.npmjs.com/package/@bestow/jsonlogic-rs) |
 | Python               | [PyPI](https://test.pypi.org/project/jsonlogic-rs/0.1.0/)                  |
 
+## Installation
+
+### Rust
+
+Just add to your `Cargo.toml`:
+
+``` toml
+[dependencies]
+jsonlogic-rs = "~0.1.1"
+```
+
+### Node/Browser
+
+You can install JsonLogic using npm or yarn. In NPM:
+
+``` sh
+npm install --save @bestow/jsonlogic-rs
+```
+
+Note that the package is distributed as a node package, so you'll need to use
+`browserify`, `webpack`, or similar to install for the browser.
+
+### Python
+
+Wheels are distributed for many platforms, so you should often be able to just
+run:
+
+``` sh
+pip install jsonlogic-rs
+```
+
+If a wheel does _not_ exist for your system, this will attempt to build the 
+package. In order for the package to build successfully, you MUST have Rust
+installed on your local system, and `cargo` MUST be present in your `PATH`.
+
+See [Building](#Building) below for more details.
+
 ## Usage
 
 ### Rust
@@ -36,6 +73,8 @@ languages. The table below describes current language support:
 use jsonlogic_rs;
 use serde_json::json;
 
+// You can pass JSON values deserialized with serde straight
+// into apply().
 fn main() {
     assert_eq!(
         jsonlogic_rs::apply(
@@ -69,6 +108,13 @@ res = jsonlogic_rs.apply(
 )
 
 assert res == True
+
+# If You have serialized JsonLogic and data, the `apply_serialized` method can 
+# be used instead
+res = jsonlogic_rs.apply_serialized(
+    '{"===": [{"var": "a"}, 7]}',
+    '{"a": 7}'
+)
 ```
 
 ## Building

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,18 @@ AUTHOR = "Matthew Planchard"
 EMAIL = "msplanchard@gmail.com"
 
 
+def generate_lockfile():
+    if (PKG_ROOT / "Cargo.lock").exists():
+        return
+    print("Generating Cargo lockfile")
+    proc = Popen(("cargo", "generate-lockfile"), stdout=PIPE, stderr=PIPE)
+    _out, err = tuple(map(bytes.decode, proc.communicate()))
+    if proc.returncode != 0:
+        raise RuntimeError(f"Could not generate Cargo lockfile: {err}")
+    return
+
 def get_version():
+    generate_lockfile()
     proc = Popen(("cargo", "pkgid"), stdout=PIPE, stderr=PIPE)
     out, err = tuple(map(bytes.decode, proc.communicate()))
     if proc.returncode != 0:


### PR DESCRIPTION
This also includes a fix to the python `setup.py` file, which was failing before if run in a situation where a Cargo lockfile was not already present, and some minor updates to the README.