### PR TITLE
FIX: Resolve distribution issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
 
   distribute-py-wheels-mac-windows:
     name: "Distribute Mac and Windows Python Wheels"
-    needs: "build-python-wheels-mac-windows"
+    needs: ["distribute", "build-python-wheels-mac-windows"]
     if: "${{ github.ref == 'refs/heads/master' }}"
     strategy:
       matrix:
@@ -554,7 +554,7 @@ jobs:
 
   distribute-py-wheels-linux:
     name: "Distribute Linux Python Wheels"
-    needs: "build-python-wheels-linux"
+    needs: ["distribute", "build-python-wheels-linux"]
     runs-on: ubuntu-latest
     if: "${{ github.ref == 'refs/heads/master' }}"
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,7 @@ jobs:
           script: |
             github.git.createRef({
               owner: "${{ github.repository_owner }}",
-              repo: "${{ github.repository }}",
+              repo: "json-logic-rs",
               ref: "refs/tags/v${{ steps.get-version.ouputs.version }}",
               sha: "${{ github.sha }}",
             })
@@ -423,7 +423,7 @@ jobs:
           script: |
             github.git.createTag({
               owner: "${{ github.repository_owner }}",
-              repo: "${{ github.repository }}",
+              repo: "json-logic-rs",
               tag: "v${{ steps.get-version.ouputs.version }}",
               message: "Vesrion ${{ steps.get-version.outputs.version }}",
               object: "${{ github.sha }}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,7 +615,7 @@ jobs:
         shell: bash
         run: |
           pip install twine
-          twine upload --skip-existing dist-py/*
+          twine upload --skip-existing dist-py/*manylinux*
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: "${{ secrets.PYPI_TOKEN }}"


### PR DESCRIPTION
The GH repository reference (used for tag creation) included the org name, which I did not expect, so I replaced it with a hard-coded string.

The Python Linux wheels failed to upload b/c it tried to upload the `linux` wheels as well as the `manylinux` wheels. PyPI only accepts the `manylinux` wheels.

I also made the wheel distribution jobs dependent on the main distribution job.