### PR TITLE
FIX: email required for GH tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
 
   distribute:
     name: "Distribute Cargo, WASM, and Python Sdist Packages"
-    needs: "build"
+    needs: ["build", "build-python-wheels-mac-windows", "build-python-wheels-linux"]
     runs-on: ubuntu-latest
     if: "${{ github.ref == 'refs/heads/master' }}"
     steps:
@@ -430,6 +430,7 @@ jobs:
               type: "commit",
               tagger: {
                 name: "${{ github.actor }}",
+                email: "msplanchard@gmail.com",
               }
             })
 


### PR DESCRIPTION
Also made all the dist steps dependent on all the build steps.