### PR TITLE
FIX: ignore version tracking artifact in git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,7 +511,7 @@ jobs:
         uses: "actions/download-artifact@v1"
         with:
           name: "new-cargo"
-          path: tmp-new-cargo-ver
+          path: "tmp-new-cargo-ver"
 
       - name: "Check for new cargo version"
         id: cargo-version
@@ -564,7 +564,7 @@ jobs:
         uses: "actions/download-artifact@v1"
         with:
           name: "new-cargo"
-          path: tmp-new-cargo-ver
+          path: "tmp-new-cargo-ver"
 
       - name: "Check for new cargo version"
         id: cargo-version

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ js/
 build/
 dist/
 venv/
+
+# Used in the CI pipeline
+tmp-new-cargo-ver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2020-07-14
+
+### Chore
+
+- A bunch of minor fixes to get the CI pipeline working for all platforms
+
 ## [0.1.1] - 2020-07-14
 
 ### Fixed
@@ -27,5 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python SDist build
 - Packages published & registered on the various package repositories
 
-[Unreleased]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.0...v0.1.2
+[0.1.1]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Bestowinc/json-logic-rs/compare/0ce0196...v0.1.0


### PR DESCRIPTION
Cargo doesn't allow publishing when the local git is dirty, so this
ignores the file we're using to track whether it's a new cargo version
across jobs