### PR TITLE
MAINT: Allow null input for some, any, and none

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           # python targets confused. The Python version is included at the
           # end so it can be partially matched by cache keys in contexts
           # where we're not iterating over python envs.
-          key: ${{ runner.os }}-${{ contains(runner.os, 'windows') && 'test-' || '' }}cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}
+          key: ${{ runner.os }}-${{ contains(runner.os, 'windows') && 'test-' || '' }}cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}-2
 
       # Cache `cargo install` built binaries
       - name: "Cache Built Binaries"
@@ -355,7 +355,8 @@ jobs:
 
   distribute:
     name: "Distribute Cargo, WASM, and Python Sdist Packages"
-    needs: ["build", "build-python-wheels-mac-windows", "build-python-wheels-linux"]
+    needs:
+      ["build", "build-python-wheels-mac-windows", "build-python-wheels-linux"]
     runs-on: ubuntu-latest
     if: "${{ github.ref == 'refs/heads/master' }}"
     steps:
@@ -382,7 +383,7 @@ jobs:
         shell: bash
         run: |
           echo "${{ steps.get-version.outputs.version }}"
-         
+
       - name: "Check if new Cargo version"
         id: cargo-version
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           # python targets confused. The Python version is included at the
           # end so it can be partially matched by cache keys in contexts
           # where we're not iterating over python envs.
-          key: ${{ runner.os }}-${{ contains(runner.os, 'windows') && 'test-' || '' }}cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}-3
+          key: ${{ runner.os }}-${{ contains(runner.os, 'windows') && 'test-' || '' }}cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}-4
 
       # Cache `cargo install` built binaries
       - name: "Cache Built Binaries"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           # python targets confused. The Python version is included at the
           # end so it can be partially matched by cache keys in contexts
           # where we're not iterating over python envs.
-          key: ${{ runner.os }}-${{ contains(runner.os, 'windows') && 'test-' || '' }}cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}-2
+          key: ${{ runner.os }}-${{ contains(runner.os, 'windows') && 'test-' || '' }}cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}-3
 
       # Cache `cargo install` built binaries
       - name: "Cache Built Binaries"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           # python targets confused. The Python version is included at the
           # end so it can be partially matched by cache keys in contexts
           # where we're not iterating over python envs.
-          key: ${{ runner.os }}-${{ contains(runner.os, 'windows') && 'test-' || '' }}cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}-4
+          key: ${{ runner.os }}-${{ contains(runner.os, 'windows') && 'test-' || '' }}cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.python-version }}
 
       # Cache `cargo install` built binaries
       - name: "Cache Built Binaries"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+### Added
 
 - A new `cmdline` feature that builds a `jsonlogic` binary for JsonLogic on
   the commandline
+
+### Fixed
+
+- `all`, `some`, and `none` will now accept an initial argument (the iterator)
+  that is or evaluates to `null`.
 
 ## [0.1.3] - 2020-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2020-08-16
+
 ### Added
 
 - A new `cmdline` feature that builds a `jsonlogic` binary for JsonLogic on
@@ -47,7 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python SDist build
 - Packages published & registered on the various package repositories
 
-[Unreleased]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.2...HEAD
-[0.1.2]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.0...v0.1.2
+[Unreleased]: https://github.com/Bestowinc/json-logic-rs/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.3...v0.2.0
+[0.1.3]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Bestowinc/json-logic-rs/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Bestowinc/json-logic-rs/compare/0ce0196...v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "jsonlogic-rs"
 readme = "README.md"
 repository = "https://github.com/bestowinc/json-logic-rs"
-version = "0.1.3"
+version = "0.2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,4 @@ test-py: $(VENV)
 venv: $(VENV)
 $(VENV): setup.py pyproject.toml
 	$(PYTHON) -m venv venv
-	$(VENV) -m pip install setuptools wheel setuptools-rust==0.11.2
+	$(VENV) -m pip install setuptools wheel setuptools-rust==0.10.6

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,4 @@ test-py: $(VENV)
 venv: $(VENV)
 $(VENV): setup.py pyproject.toml
 	$(PYTHON) -m venv venv
-	$(VENV) -m pip install setuptools wheel setuptools-rust==0.10.6
+	$(VENV) -m pip install setuptools wheel setuptools-rust==0.11.0

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,10 @@ test-wasm:
 test-py: $(VENV)
 	$(VENV) tests/test_py.py
 
+# Note: please change both here and in the build-wheels script if specifying a
+# particular version or removing the version pin. setuptools-rust is currently
+# pinned because the windows builds were broken with v0.11.3.
 venv: $(VENV)
 $(VENV): setup.py pyproject.toml
 	$(PYTHON) -m venv venv
-	$(VENV) -m pip install setuptools wheel setuptools-rust
+	$(VENV) -m pip install setuptools wheel setuptools-rust==0.10.6

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,4 @@ test-py: $(VENV)
 venv: $(VENV)
 $(VENV): setup.py pyproject.toml
 	$(PYTHON) -m venv venv
-	$(VENV) -m pip install setuptools wheel setuptools-rust==0.11.2
+	$(VENV) -m pip install setuptools wheel setuptools-rust==0.11.0

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,4 @@ test-py: $(VENV)
 venv: $(VENV)
 $(VENV): setup.py pyproject.toml
 	$(PYTHON) -m venv venv
-	$(VENV) -m pip install setuptools wheel setuptools-rust==0.11.1
+	$(VENV) -m pip install setuptools wheel setuptools-rust==0.11.2

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,4 @@ test-py: $(VENV)
 venv: $(VENV)
 $(VENV): setup.py pyproject.toml
 	$(PYTHON) -m venv venv
-	$(VENV) -m pip install setuptools wheel setuptools-rust==0.11.0
+	$(VENV) -m pip install setuptools wheel setuptools-rust==0.11.1

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -17,7 +17,9 @@ for PYBIN in /opt/python/{cp36-cp36m,cp37-cp37m,cp38-cp38}/bin; do
     export PYTHON_SYS_EXECUTABLE="$PYBIN/python"
 
     "${PYBIN}/python" -m ensurepip
-    "${PYBIN}/python" -m pip install -U setuptools wheel setuptools-rust
+    # Note: please change both here and in the makefile if specifying a particular
+    # version or removing the version pin.
+    "${PYBIN}/python" -m pip install -U setuptools wheel setuptools-rust==0.10.6
     "${PYBIN}/python" setup.py bdist_wheel
 done
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -578,12 +578,12 @@ mod jsonlogic_tests {
         vec![
             // Invalid first arguments
             (json!({"all": [1, 1]}), json!({}), Err(())),
-            (json!({"all": [null, 1]}), json!({}), Err(())),
             (json!({"all": [{}, 1]}), json!({}), Err(())),
             (json!({"all": [false, 1]}), json!({}), Err(())),
-            // Empty array/string
+            // Empty array/string/null
             (json!({"all": [[], 1]}), json!({}), Ok(json!(false))),
             (json!({"all": ["", 1]}), json!({}), Ok(json!(false))),
+            (json!({"all": [null, 1]}), json!({}), Ok(json!(false))),
             // Constant predicate
             (json!({"all": [[1, 2], 1]}), json!({}), Ok(json!(true))),
             (json!({"all": [[1, 2], 0]}), json!({}), Ok(json!(false))),
@@ -607,6 +607,12 @@ mod jsonlogic_tests {
                 json!({"all": ["aabaa", {"===": [{"var": ""}, "a"]}]}),
                 json!({}),
                 Ok(json!(false)),
+            ),
+            // First argument requires evaluation
+            (
+                json!({"all": [ {"var": "a"}, {"===": [{"var": ""}, "a"]} ]}),
+                json!({"a": "a"}),
+                Ok(json!(true)),
             ),
             // Expression in array
             (
@@ -648,6 +654,11 @@ mod jsonlogic_tests {
                 json!({"foo": -5}),
                 Ok(json!(false)),
             ),
+            (
+                json!({"all": [[1, {"var": "foo"}], {">": [{"var": ""}, 0]}]}),
+                json!({"foo": -5}),
+                Ok(json!(false)),
+            ),
         ]
     }
 
@@ -655,12 +666,12 @@ mod jsonlogic_tests {
         vec![
             // Invalid first arguments
             (json!({"some": [1, 1]}), json!({}), Err(())),
-            (json!({"some": [null, 1]}), json!({}), Err(())),
             (json!({"some": [{}, 1]}), json!({}), Err(())),
             (json!({"some": [false, 1]}), json!({}), Err(())),
             // Empty array/string
             (json!({"some": [[], 1]}), json!({}), Ok(json!(false))),
             (json!({"some": ["", 1]}), json!({}), Ok(json!(false))),
+            (json!({"some": [null, 1]}), json!({}), Ok(json!(false))),
             // Constant predicate
             (json!({"some": [[1, 2], 1]}), json!({}), Ok(json!(true))),
             (json!({"some": [[1, 2], 0]}), json!({}), Ok(json!(false))),
@@ -737,12 +748,12 @@ mod jsonlogic_tests {
         vec![
             // Invalid first arguments
             (json!({"none": [1, 1]}), json!({}), Err(())),
-            (json!({"none": [null, 1]}), json!({}), Err(())),
             (json!({"none": [{}, 1]}), json!({}), Err(())),
             (json!({"none": [false, 1]}), json!({}), Err(())),
             // Empty array/string
             (json!({"none": [[], 1]}), json!({}), Ok(json!(true))),
             (json!({"none": ["", 1]}), json!({}), Ok(json!(true))),
+            (json!({"none": [null, 1]}), json!({}), Ok(json!(true))),
             // Constant predicate
             (json!({"none": [[1, 2], 1]}), json!({}), Ok(json!(false))),
             (json!({"none": [[1, 2], 0]}), json!({}), Ok(json!(true))),

--- a/src/op/array.rs
+++ b/src/op/array.rs
@@ -178,11 +178,18 @@ pub fn all(data: &Value, args: &Vec<&Value>) -> Result<Value, Error> {
                 .collect();
             &_new_arr
         }
+        Value::Null => {
+            _new_arr = Vec::new();
+            &_new_arr
+        }
         _ => {
             return Err(Error::InvalidArgument {
                 value: first_arg.clone(),
                 operation: "all".into(),
-                reason: "First argument to all must be an array or a string".into(),
+                reason: format!(
+                "First argument to all must evaluate to an array, string, or null, got {}",
+                potentially_evaled_first_arg
+            ),
             })
         }
     };
@@ -253,13 +260,18 @@ pub fn some(data: &Value, args: &Vec<&Value>) -> Result<Value, Error> {
                 .collect();
             &_new_arr
         }
-        _ => {
-            return Err(Error::InvalidArgument {
-                value: first_arg.clone(),
-                operation: "all".into(),
-                reason: "First argument to all must be an array or a string".into(),
-            })
+        Value::Null => {
+            _new_arr = Vec::new();
+            &_new_arr
         }
+        _ => return Err(Error::InvalidArgument {
+            value: first_arg.clone(),
+            operation: "all".into(),
+            reason: format!(
+                "First argument must evaluate to an array, a string, or null, got {}",
+                potentially_evaled_first_arg
+            ),
+        }),
     };
 
     // Special-case the empty array, since it for some reason is specified


### PR DESCRIPTION
While the original jsonlogic implementation _does_ throw an error here,
several of the other implementations do not. Because the behavior in the
original specification is unspecified, I'm choosing to go with the more
flexible option.

Note: this branch also includes a pin to `setuptools-rust`, because recent
versions were causing an issue with the windows builds. There are a number
of commits in here to determine specifically which versions were broken
to help in reporting the issue (see PyO3/setuptools-rust#81).