### PR TITLE
MAINT: Allow null values for `in` target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2020-08-16
+## [0.2.1] - 2020-08-17
+
+### Changed
+
+- `in` will now accept `null` or anything that evaluates to `null` for its
+  second argument
+
+## [0.2.0] - 2020-08-17
 
 ### Added
 
 - A new `cmdline` feature that builds a `jsonlogic` binary for JsonLogic on
   the commandline
 
-### Fixed
+### Changed
 
 - `all`, `some`, and `none` will now accept an initial argument (the iterator)
   that is or evaluates to `null`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "jsonlogic-rs"
 readme = "README.md"
 repository = "https://github.com/bestowinc/json-logic-rs"
-version = "0.2.0"
+version = "0.2.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1095,14 +1095,18 @@ mod jsonlogic_tests {
 
     fn in_cases() -> Vec<(Value, Value, Result<Value, ()>)> {
         vec![
+            // Invalid inputs
             (json!( {"in": []} ), json!({}), Err(())),
             (json!( {"in": [1, [], 1]} ), json!({}), Err(())),
             (json!( {"in": [1, "foo"]} ), json!({}), Err(())),
             (json!( {"in": [1, 1]} ), json!({}), Err(())),
+            // Valid inputs
+            (json!( {"in": [1, null]} ), json!({}), Ok(json!(false))),
             (json!( {"in": [1, [1, 2]]} ), json!({}), Ok(json!(true))),
             (json!( {"in": [1, [0, 2]]} ), json!({}), Ok(json!(false))),
             (json!( {"in": ["f", "foo"]} ), json!({}), Ok(json!(true))),
             (json!( {"in": ["f", "bar"]} ), json!({}), Ok(json!(false))),
+            (json!( {"in": ["f", null]} ), json!({}), Ok(json!(false))),
             (
                 json!( {"in": [null, [1, null]]} ),
                 json!({}),

--- a/src/op/array.rs
+++ b/src/op/array.rs
@@ -264,14 +264,16 @@ pub fn some(data: &Value, args: &Vec<&Value>) -> Result<Value, Error> {
             _new_arr = Vec::new();
             &_new_arr
         }
-        _ => return Err(Error::InvalidArgument {
-            value: first_arg.clone(),
-            operation: "all".into(),
-            reason: format!(
+        _ => {
+            return Err(Error::InvalidArgument {
+                value: first_arg.clone(),
+                operation: "all".into(),
+                reason: format!(
                 "First argument must evaluate to an array, a string, or null, got {}",
                 potentially_evaled_first_arg
             ),
-        }),
+            })
+        }
     };
 
     // Special-case the empty array, since it for some reason is specified
@@ -352,6 +354,7 @@ pub fn in_(items: &Vec<&Value>) -> Result<Value, Error> {
         // Given that anyone relying on this behavior in the existing jsonlogic
         // implementation is relying on broken, undefined behavior, it seems
         // okay to update that behavior to work in a more intuitive way.
+        Value::Null => Ok(Value::Bool(false)),
         Value::Array(possibles) => Ok(Value::Bool(possibles.contains(needle))),
         Value::String(haystack_string) => {
             // Note: the reference implementation uses the regular old


### PR DESCRIPTION
Allows `null` or values that evaluate to `null` for the second argument
of `in` (the haystack) to improve compatibility with other jsonlogic
implementations.