### PR TITLE
Documentation fix: Fix PyPI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ languages. The table below describes current language support:
 | -------------------- | -------------------------------------------------------------------------- |
 | Rust                 | [Cargo](https://crates.io/crates/jsonlogic-rs)                             |
 | JavaScript (as WASM) | Node Package via [NPM](https://www.npmjs.com/package/@bestow/jsonlogic-rs) |
-| Python               | [PyPI](https://test.pypi.org/project/jsonlogic-rs/0.1.0/)                  |
+| Python               | [PyPI](https://pypi.org/project/jsonlogic-rs/)                             |
 
 ## Installation
 


### PR DESCRIPTION
The [current link]((https://test.pypi.org/project/jsonlogic-rs/0.1.0/) to PyPI links to the test release, leading me to think only version 1.0 was published to PyPI. This changes the link so it links to the latest release.