### PR TITLE
Major performance improvement achieved through fixing clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,10 @@ jobs:
       - name: "Generate Cargo Lockfile"
         run: "cargo generate-lockfile"
 
+      - name: "Run clippy"
+        shell: bash
+        run: "cargo clippy --all --tests -- -D warnings"
+
       # Cache build dependencies
       - name: "Cache Build Fragments"
         id: "cache-build-fragments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["cmdline"]
 cmdline = ["anyhow", "clap"]
 default = []
 python = ["cpython"]
-wasm = ["serde-wasm-bindgen", "wasm-bindgen"]
+wasm = ["wasm-bindgen", "gloo-utils"]
 
 [dependencies]
 phf = { version = "~0.8.0", features = ["macros"] }
@@ -39,10 +39,11 @@ features = ["serde-serialize"]
 optional = true
 version = "~0.2.62"
 
-[dependencies.serde-wasm-bindgen]
+[dependencies.gloo-utils]
 features = []
 optional = true
-version = "~0.6.5"
+version = "~0.2.0"
+
 
 [dependencies.serde]
 features = ["derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ required-features = ["cmdline"]
 cmdline = ["anyhow", "clap"]
 default = []
 python = ["cpython"]
-wasm = ["wasm-bindgen"]
+wasm = ["serde-wasm-bindgen", "wasm-bindgen"]
 
 [dependencies]
-phf = {version = "~0.8.0", features = ["macros"]}
+phf = { version = "~0.8.0", features = ["macros"] }
 serde_json = "~1.0.41"
 thiserror = "~1.0.11"
 
@@ -38,6 +38,15 @@ thiserror = "~1.0.11"
 features = ["serde-serialize"]
 optional = true
 version = "~0.2.62"
+
+[dependencies.serde-wasm-bindgen]
+features = []
+optional = true
+version = "~0.6.5"
+
+[dependencies.serde]
+features = ["derive"]
+version = "1"
 
 [dependencies.cpython]
 features = ["extension-module"]

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -3,10 +3,7 @@ use std::io::Read;
 
 use anyhow::{Context, Result};
 use clap::{App, Arg};
-use serde_json;
 use serde_json::Value;
-
-use jsonlogic_rs;
 
 fn configure_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
     app.version(env!("CARGO_PKG_VERSION"))
@@ -67,7 +64,7 @@ fn main() -> Result<()> {
     let result = jsonlogic_rs::apply(&json_logic, &json_data)
         .context("Could not execute logic")?;
 
-    println!("{}", result.to_string());
+    println!("{}", result);
 
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 //! Error handling
 //!
 use serde_json::Value;
-use thiserror;
 
 use crate::op::NumParams;
 
@@ -30,6 +29,7 @@ pub enum Error {
     #[error("Invalid variable mapping - {0} is not an object.")]
     InvalidVarMap(Value),
 
+    #[allow(clippy::enum_variant_names)]
     #[error("Encountered an unexpected error. Please raise an issue on GitHub and include the following error message: {0}")]
     UnexpectedError(String),
 

--- a/src/js_op.rs
+++ b/src/js_op.rs
@@ -434,7 +434,7 @@ pub fn abstract_max(items: &Vec<&Value>) -> Result<f64, Error> {
     items
         .into_iter()
         .map(|v| {
-            to_number(v).ok_or(Error::InvalidArgument {
+            to_number(v).ok_or_else(|| Error::InvalidArgument {
                 value: (*v).clone(),
                 operation: "max".into(),
                 reason: "Could not convert value to number".into(),
@@ -460,7 +460,7 @@ pub fn abstract_min(items: &Vec<&Value>) -> Result<f64, Error> {
     items
         .into_iter()
         .map(|v| {
-            to_number(v).ok_or(Error::InvalidArgument {
+            to_number(v).ok_or_else(|| Error::InvalidArgument {
                 value: (*v).clone(),
                 operation: "max".into(),
                 reason: "Could not convert value to number".into(),
@@ -518,7 +518,7 @@ pub fn abstract_plus(first: &Value, second: &Value) -> Value {
 pub fn parse_float_add(vals: &Vec<&Value>) -> Result<f64, Error> {
     vals.into_iter()
         .map(|&v| {
-            parse_float(v).ok_or(Error::InvalidArgument {
+            parse_float(v).ok_or_else(|| Error::InvalidArgument {
                 value: v.clone(),
                 operation: "+".into(),
                 reason: "Argument could not be converted to a float".into(),
@@ -541,7 +541,7 @@ pub fn parse_float_add(vals: &Vec<&Value>) -> Result<f64, Error> {
 pub fn parse_float_mul(vals: &Vec<&Value>) -> Result<f64, Error> {
     vals.into_iter()
         .map(|&v| {
-            parse_float(v).ok_or(Error::InvalidArgument {
+            parse_float(v).ok_or_else(|| Error::InvalidArgument {
                 value: v.clone(),
                 operation: "*".into(),
                 reason: "Argument could not be converted to a float".into(),
@@ -629,7 +629,7 @@ pub fn abstract_mod(first: &Value, second: &Value) -> Result<f64, Error> {
 pub fn to_negative(val: &Value) -> Result<f64, Error> {
     to_number(val)
         .map(|v| -1.0 * v)
-        .ok_or(Error::InvalidArgument {
+        .ok_or_else(|| Error::InvalidArgument {
             value: val.clone(),
             operation: "to_negative".into(),
             reason: "Could not convert value to a number".into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ trait Parser<'a>: Sized + Into<Value> {
 
 #[cfg(feature = "wasm")]
 pub mod javascript_iface {
+    use gloo_utils::format::JsValueSerdeExt;
     use serde_json::Value;
     use wasm_bindgen::prelude::*;
 
@@ -33,7 +34,8 @@ pub mod javascript_iface {
             serde_json::from_str(&js_string).or(Ok(Value::String(js_string)))
         } else {
             // If we're passed anything else, convert it directly to a serde Value.
-            serde_wasm_bindgen::from_value(js_value)
+
+            JsValueSerdeExt::into_serde::<Value>(&js_value)
                 .map_err(|err| format!("{}", err))
                 .map_err(JsValue::from)
         }
@@ -48,7 +50,7 @@ pub mod javascript_iface {
             .map_err(|err| format!("{}", err))
             .map_err(JsValue::from)?;
 
-        serde_wasm_bindgen::to_value(&res)
+        <wasm_bindgen::JsValue as JsValueSerdeExt>::from_serde(&res)
             .map_err(|err| format!("{}", err))
             .map_err(JsValue::from)
     }

--- a/src/op/data.rs
+++ b/src/op/data.rs
@@ -216,7 +216,7 @@ fn get_key(data: &Value, key: KeyType) -> Option<Value> {
         KeyType::String(k) => get_str_key(data, k),
         KeyType::Number(i) => match data {
             Value::Object(_) => get_str_key(data, i.to_string()),
-            Value::Array(arr) => get(arr, i).map(Value::clone),
+            Value::Array(arr) => get(arr, i).cloned(),
             Value::String(s) => {
                 let s_vec: Vec<char> = s.chars().collect();
                 get(&s_vec, i).map(|c| c.to_string()).map(Value::String)
@@ -236,14 +236,12 @@ fn get_str_key<K: AsRef<str>>(data: &Value, key: K) -> Option<Value> {
             // Exterior ref in case we need to make a new value in the match.
             k.split('.').try_fold(data.clone(), |acc, i| match acc {
                 // If the current value is an object, try to get the value
-                Value::Object(map) => map.get(i).map(Value::clone),
+                Value::Object(map) => map.get(i).cloned(),
                 // If the current value is an array, we need an integer
                 // index. If integer conversion fails, return None.
-                Value::Array(arr) => i
-                    .parse::<i64>()
-                    .ok()
-                    .and_then(|i| get(&arr, i))
-                    .map(Value::clone),
+                Value::Array(arr) => {
+                    i.parse::<i64>().ok().and_then(|i| get(&arr, i)).cloned()
+                }
                 // Same deal if it's a string.
                 Value::String(s) => {
                     let s_chars: Vec<char> = s.chars().collect();

--- a/src/op/data.rs
+++ b/src/op/data.rs
@@ -23,12 +23,12 @@ impl<'a> TryFrom<Value> for KeyType<'a> {
         match value {
             Value::Null => Ok(Self::Null),
             Value::String(s) => Ok(Self::String(Cow::from(s))),
-            Value::Number(n) => Ok(Self::Number(n.as_i64().ok_or(
+            Value::Number(n) => Ok(Self::Number(n.as_i64().ok_or_else(|| {
                 Error::InvalidVariableKey {
                     value: Value::Number(n),
                     reason: "Numeric keys must be valid integers".into(),
-                },
-            )?)),
+                }
+            })?)),
             _ => Err(Error::InvalidVariableKey {
                 value: value.clone(),
                 reason: "Variable keys must be strings, integers, or null".into(),
@@ -43,12 +43,12 @@ impl<'a> TryFrom<&'a Value> for KeyType<'a> {
         match value {
             Value::Null => Ok(Self::Null),
             Value::String(s) => Ok(Self::String(Cow::from(s))),
-            Value::Number(n) => Ok(Self::Number(n.as_i64().ok_or(
+            Value::Number(n) => Ok(Self::Number(n.as_i64().ok_or_else(|| {
                 Error::InvalidVariableKey {
                     value: value.clone(),
                     reason: "Numeric keys must be valid integers".into(),
-                },
-            )?)),
+                }
+            })?)),
             _ => Err(Error::InvalidVariableKey {
                 value: value.clone(),
                 reason: "Variable keys must be strings, integers, or null".into(),
@@ -155,7 +155,7 @@ pub fn missing_some(data: &Value, args: &Vec<&Value>) -> Result<Value, Error> {
         Value::Number(n) => n.as_u64(),
         _ => None,
     }
-    .ok_or(Error::InvalidArgument {
+    .ok_or_else(|| Error::InvalidArgument {
         value: threshold_arg.clone(),
         operation: "missing_some".into(),
         reason: "missing_some threshold must be a valid, positive integer".into(),

--- a/src/op/impure.rs
+++ b/src/op/impure.rs
@@ -9,7 +9,7 @@ use crate::error::Error;
 /// The reference implementation ignores any arguments beyond the first,
 /// and the specification seems to indicate that the first argument is
 /// the only one considered, so we're doing the same.
-pub fn log(items: &Vec<&Value>) -> Result<Value, Error> {
+pub fn log(items: &[&Value]) -> Result<Value, Error> {
     println!("{}", items[0]);
     Ok(items[0].clone())
 }

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -501,14 +501,18 @@ fn op_from_map<'a, 'b, T: CommonOperator>(
 
     // We've already validated the length to be one, so any error
     // here is super unexpected.
-    let key = obj.keys().next().ok_or(Error::UnexpectedError(format!(
-        "could not get first key from len(1) object: {:?}",
-        obj
-    )))?;
-    let val = obj.get(key).ok_or(Error::UnexpectedError(format!(
-        "could not get value for key '{}' from len(1) object: {:?}",
-        key, obj
-    )))?;
+    let key = obj.keys().next().ok_or_else(|| {
+        Error::UnexpectedError(format!(
+            "could not get first key from len(1) object: {:?}",
+            obj
+        ))
+    })?;
+    let val = obj.get(key).ok_or_else(|| {
+        Error::UnexpectedError(format!(
+            "could not get value for key '{}' from len(1) object: {:?}",
+            key, obj
+        ))
+    })?;
 
     // See if the key is an operator. If it's not, return None.
     let op = match map.get(key.as_str()) {

--- a/src/op/numeric.rs
+++ b/src/op/numeric.rs
@@ -6,7 +6,7 @@ use crate::error::Error;
 use crate::js_op;
 use crate::value::to_number_value;
 
-fn compare<F>(func: F, items: &Vec<&Value>) -> Result<Value, Error>
+fn compare<F>(func: F, items: &[&Value]) -> Result<Value, Error>
 where
     F: Fn(&Value, &Value) -> bool,
 {
@@ -20,27 +20,27 @@ where
 }
 
 /// Do < for either 2 or 3 values
-pub fn lt(items: &Vec<&Value>) -> Result<Value, Error> {
+pub fn lt(items: &[&Value]) -> Result<Value, Error> {
     compare(js_op::abstract_lt, items)
 }
 
 /// Do <= for either 2 or 3 values
-pub fn lte(items: &Vec<&Value>) -> Result<Value, Error> {
+pub fn lte(items: &[&Value]) -> Result<Value, Error> {
     compare(js_op::abstract_lte, items)
 }
 
 /// Do > for either 2 or 3 values
-pub fn gt(items: &Vec<&Value>) -> Result<Value, Error> {
+pub fn gt(items: &[&Value]) -> Result<Value, Error> {
     compare(js_op::abstract_gt, items)
 }
 
 /// Do >= for either 2 or 3 values
-pub fn gte(items: &Vec<&Value>) -> Result<Value, Error> {
+pub fn gte(items: &[&Value]) -> Result<Value, Error> {
     compare(js_op::abstract_gte, items)
 }
 
 /// Perform subtraction or convert a number to a negative
-pub fn minus(items: &Vec<&Value>) -> Result<Value, Error> {
+pub fn minus(items: &[&Value]) -> Result<Value, Error> {
     let value = if items.len() == 1 {
         js_op::to_negative(items[0])?
     } else {

--- a/src/op/string.rs
+++ b/src/op/string.rs
@@ -15,16 +15,16 @@ use crate::NULL;
 /// evaluates to `"foo[object Object]". Here we explicitly require all
 /// arguments to be strings, because the specification explicitly defines
 /// `cat` as a string operation.
-pub fn cat(items: &Vec<&Value>) -> Result<Value, Error> {
+pub fn cat(items: &[&Value]) -> Result<Value, Error> {
     let mut rv = String::from("");
     items
-        .into_iter()
+        .iter()
         .map(|i| match i {
             Value::String(i_string) => Ok(i_string.clone()),
             _ => Ok(js_op::to_string(i)),
         })
-        .fold(Ok(&mut rv), |acc: Result<&mut String, Error>, i| {
-            let rv = acc?;
+        .try_fold(&mut rv, |acc: &mut String, i| {
+            let rv = acc;
             rv.push_str(&i?);
             Ok(rv)
         })?;
@@ -36,15 +36,14 @@ pub fn cat(items: &Vec<&Value>) -> Result<Value, Error> {
 /// Note: the reference implementation casts the first argument to a string,
 /// but since the specification explicitly defines this as a string operation,
 /// the argument types are enforced here to avoid unpredictable behavior.
-pub fn substr(items: &Vec<&Value>) -> Result<Value, Error> {
+pub fn substr(items: &[&Value]) -> Result<Value, Error> {
     // We can only have 2 or 3 arguments. Number of arguments is validated elsewhere.
     let (string_arg, idx_arg) = (items[0], items[1]);
-    let limit_opt: Option<&Value>;
-    if items.len() > 2 {
-        limit_opt = Some(items[2]);
+    let limit_opt = if items.len() > 2 {
+        Some(items[2])
     } else {
-        limit_opt = None;
-    }
+        None
+    };
 
     let string = match string_arg {
         Value::String(s) => s,
@@ -85,7 +84,8 @@ pub fn substr(items: &Vec<&Value>) -> Result<Value, Error> {
                     Err(Error::InvalidArgument {
                         value: limit_arg.clone(),
                         operation: "substr".into(),
-                        reason: "Optional third argument to substr must be an integer".into(),
+                        reason: "Optional third argument to substr must be an integer"
+                            .into(),
                     })
                 }
             }
@@ -111,7 +111,7 @@ pub fn substr(items: &Vec<&Value>) -> Result<Value, Error> {
         // If the index is negative it means "number of characters prior to the
         // end of the string from which to start", and corresponds to the string
         // length minus the index.
-        idx if idx < 0 => string_len.checked_sub(idx_abs).unwrap_or(0),
+        idx if idx < 0 => string_len.saturating_sub(idx_abs),
         // A positive index is simply the starting point. Max starting point
         // is the length, which will yield an empty string.
         _ => cmp::min(string_len, idx_abs),
@@ -120,19 +120,20 @@ pub fn substr(items: &Vec<&Value>) -> Result<Value, Error> {
     let end_idx = match limit {
         None => string_len,
         Some(l) => {
-            let limit_abs: usize = l.abs().try_into().map_err(|e| Error::InvalidArgument {
-                value: limit_opt.or(Some(&NULL)).map(|v| v.clone()).unwrap(),
-                operation: "substr".into(),
-                reason: format!(
-                    "The number {} is too large to index strings on this system",
-                    e
-                ),
-            })?;
+            let limit_abs: usize =
+                l.abs().try_into().map_err(|e| Error::InvalidArgument {
+                    value: limit_opt.or(Some(&NULL)).cloned().unwrap(),
+                    operation: "substr".into(),
+                    reason: format!(
+                        "The number {} is too large to index strings on this system",
+                        e
+                    ),
+                })?;
             match l {
                 // If the limit is negative, it means "characters before the end
                 // at which to stop", corresponding to an index of either 0 or
                 // the length of the string minus the limit.
-                l if l < 0 => string_len.checked_sub(limit_abs).unwrap_or(0),
+                l if l < 0 => string_len.saturating_sub(limit_abs),
                 // A positive limit indicates the number of characters to take,
                 // so it corresponds to an index of the start index plus the
                 // limit (with a maximum value of the string length).
@@ -144,7 +145,7 @@ pub fn substr(items: &Vec<&Value>) -> Result<Value, Error> {
         }
     };
 
-    let count_in_substr = end_idx.checked_sub(start_idx).unwrap_or(0);
+    let count_in_substr = end_idx.saturating_sub(start_idx);
 
     // Iter over our expected count rather than indexing directly to avoid
     // potential panics if any of our math is wrong.

--- a/src/value.rs
+++ b/src/value.rs
@@ -26,10 +26,9 @@ impl<'a> Parsed<'a> {
             .or(LazyOperation::from_value(value)?.map(Self::LazyOperation))
             .or(DataOperation::from_value(value)?.map(Self::DataOperation))
             .or(Raw::from_value(value)?.map(Self::Raw))
-            .ok_or(Error::UnexpectedError(format!(
-                "Failed to parse Value {:?}",
-                value
-            )))
+            .ok_or_else(|| {
+                Error::UnexpectedError(format!("Failed to parse Value {:?}", value))
+            })
     }
 
     pub fn from_values(values: Vec<&'a Value>) -> Result<Vec<Self>, Error> {
@@ -106,10 +105,12 @@ pub fn to_number_value(number: f64) -> Result<Value, Error> {
         Ok(Value::Number(Number::from(number as i64)))
     } else {
         Number::from_f64(number)
-            .ok_or(Error::UnexpectedError(format!(
-                "Could not make JSON number from result {:?}",
-                number
-            )))
+            .ok_or_else(|| {
+                Error::UnexpectedError(format!(
+                    "Could not make JSON number from result {:?}",
+                    number
+                ))
+            })
             .map(Value::Number)
     }
 }

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -4,11 +4,11 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
-use reqwest;
-use serde_json;
+
+
 use serde_json::Value;
 
-use jsonlogic_rs;
+
 
 struct TestCase {
     logic: Value,
@@ -16,7 +16,7 @@ struct TestCase {
     result: Value,
 }
 
-const TEST_URL: &'static str = "http://jsonlogic.com/tests.json";
+const TEST_URL: &str = "http://jsonlogic.com/tests.json";
 
 fn load_file_json() -> Value {
     let mut file = File::open(Path::join(
@@ -57,7 +57,7 @@ fn check_test_file() {
         Ok(r) => r,
         Err(e) => {
             println!("Failed to get new version of test JSON: {:?}", e);
-            return ();
+            return ;
         }
     };
     let http_json: Value = serde_json::from_str(&resp).unwrap();


### PR DESCRIPTION
Most notable performance problem was the code used `Result::ok_or()` instead of `Result::ok_or_else(||)`, thus causing the creation of the error strings / objects regardless of whether there was an error or not. This reduced `Parsed::from_value()` times about 50 fold.

I then followed to fix all clippy warnings, and to add a `cargo clippy` step to the `ci.yaml` build section, so that we ensure clippy is happy in the future too.