### PR TITLE
perf: Replacing ok_or() calls with ok_or_else(||) calls, to improve performance

### DIFF
--- a/src/js_op.rs
+++ b/src/js_op.rs
@@ -434,7 +434,7 @@ pub fn abstract_max(items: &Vec<&Value>) -> Result<f64, Error> {
     items
         .into_iter()
         .map(|v| {
-            to_number(v).ok_or(Error::InvalidArgument {
+            to_number(v).ok_or_else(|| Error::InvalidArgument {
                 value: (*v).clone(),
                 operation: "max".into(),
                 reason: "Could not convert value to number".into(),
@@ -460,7 +460,7 @@ pub fn abstract_min(items: &Vec<&Value>) -> Result<f64, Error> {
     items
         .into_iter()
         .map(|v| {
-            to_number(v).ok_or(Error::InvalidArgument {
+            to_number(v).ok_or_else(|| Error::InvalidArgument {
                 value: (*v).clone(),
                 operation: "max".into(),
                 reason: "Could not convert value to number".into(),
@@ -518,7 +518,7 @@ pub fn abstract_plus(first: &Value, second: &Value) -> Value {
 pub fn parse_float_add(vals: &Vec<&Value>) -> Result<f64, Error> {
     vals.into_iter()
         .map(|&v| {
-            parse_float(v).ok_or(Error::InvalidArgument {
+            parse_float(v).ok_or_else(|| Error::InvalidArgument {
                 value: v.clone(),
                 operation: "+".into(),
                 reason: "Argument could not be converted to a float".into(),
@@ -541,7 +541,7 @@ pub fn parse_float_add(vals: &Vec<&Value>) -> Result<f64, Error> {
 pub fn parse_float_mul(vals: &Vec<&Value>) -> Result<f64, Error> {
     vals.into_iter()
         .map(|&v| {
-            parse_float(v).ok_or(Error::InvalidArgument {
+            parse_float(v).ok_or_else(|| Error::InvalidArgument {
                 value: v.clone(),
                 operation: "*".into(),
                 reason: "Argument could not be converted to a float".into(),
@@ -629,7 +629,7 @@ pub fn abstract_mod(first: &Value, second: &Value) -> Result<f64, Error> {
 pub fn to_negative(val: &Value) -> Result<f64, Error> {
     to_number(val)
         .map(|v| -1.0 * v)
-        .ok_or(Error::InvalidArgument {
+        .ok_or_else(|| Error::InvalidArgument {
             value: val.clone(),
             operation: "to_negative".into(),
             reason: "Could not convert value to a number".into(),

--- a/src/op/data.rs
+++ b/src/op/data.rs
@@ -23,12 +23,12 @@ impl<'a> TryFrom<Value> for KeyType<'a> {
         match value {
             Value::Null => Ok(Self::Null),
             Value::String(s) => Ok(Self::String(Cow::from(s))),
-            Value::Number(n) => Ok(Self::Number(n.as_i64().ok_or(
+            Value::Number(n) => Ok(Self::Number(n.as_i64().ok_or_else(|| {
                 Error::InvalidVariableKey {
                     value: Value::Number(n),
                     reason: "Numeric keys must be valid integers".into(),
-                },
-            )?)),
+                }
+            })?)),
             _ => Err(Error::InvalidVariableKey {
                 value: value.clone(),
                 reason: "Variable keys must be strings, integers, or null".into(),
@@ -43,12 +43,12 @@ impl<'a> TryFrom<&'a Value> for KeyType<'a> {
         match value {
             Value::Null => Ok(Self::Null),
             Value::String(s) => Ok(Self::String(Cow::from(s))),
-            Value::Number(n) => Ok(Self::Number(n.as_i64().ok_or(
+            Value::Number(n) => Ok(Self::Number(n.as_i64().ok_or_else(|| {
                 Error::InvalidVariableKey {
                     value: value.clone(),
                     reason: "Numeric keys must be valid integers".into(),
-                },
-            )?)),
+                }
+            })?)),
             _ => Err(Error::InvalidVariableKey {
                 value: value.clone(),
                 reason: "Variable keys must be strings, integers, or null".into(),
@@ -155,7 +155,7 @@ pub fn missing_some(data: &Value, args: &Vec<&Value>) -> Result<Value, Error> {
         Value::Number(n) => n.as_u64(),
         _ => None,
     }
-    .ok_or(Error::InvalidArgument {
+    .ok_or_else(|| Error::InvalidArgument {
         value: threshold_arg.clone(),
         operation: "missing_some".into(),
         reason: "missing_some threshold must be a valid, positive integer".into(),

--- a/src/op/mod.rs
+++ b/src/op/mod.rs
@@ -501,14 +501,18 @@ fn op_from_map<'a, 'b, T: CommonOperator>(
 
     // We've already validated the length to be one, so any error
     // here is super unexpected.
-    let key = obj.keys().next().ok_or(Error::UnexpectedError(format!(
-        "could not get first key from len(1) object: {:?}",
-        obj
-    )))?;
-    let val = obj.get(key).ok_or(Error::UnexpectedError(format!(
-        "could not get value for key '{}' from len(1) object: {:?}",
-        key, obj
-    )))?;
+    let key = obj.keys().next().ok_or_else(|| {
+        Error::UnexpectedError(format!(
+            "could not get first key from len(1) object: {:?}",
+            obj
+        ))
+    })?;
+    let val = obj.get(key).ok_or_else(|| {
+        Error::UnexpectedError(format!(
+            "could not get value for key '{}' from len(1) object: {:?}",
+            key, obj
+        ))
+    })?;
 
     // See if the key is an operator. If it's not, return None.
     let op = match map.get(key.as_str()) {

--- a/src/value.rs
+++ b/src/value.rs
@@ -26,10 +26,9 @@ impl<'a> Parsed<'a> {
             .or(LazyOperation::from_value(value)?.map(Self::LazyOperation))
             .or(DataOperation::from_value(value)?.map(Self::DataOperation))
             .or(Raw::from_value(value)?.map(Self::Raw))
-            .ok_or(Error::UnexpectedError(format!(
-                "Failed to parse Value {:?}",
-                value
-            )))
+            .ok_or_else(|| {
+                Error::UnexpectedError(format!("Failed to parse Value {:?}", value))
+            })
     }
 
     pub fn from_values(values: Vec<&'a Value>) -> Result<Vec<Self>, Error> {
@@ -106,10 +105,12 @@ pub fn to_number_value(number: f64) -> Result<Value, Error> {
         Ok(Value::Number(Number::from(number as i64)))
     } else {
         Number::from_f64(number)
-            .ok_or(Error::UnexpectedError(format!(
-                "Could not make JSON number from result {:?}",
-                number
-            )))
+            .ok_or_else(|| {
+                Error::UnexpectedError(format!(
+                    "Could not make JSON number from result {:?}",
+                    number
+                ))
+            })
             .map(Value::Number)
     }
 }


### PR DESCRIPTION

(cherry picked from commit ebc57709e312ea3adc814c427419a57ad8fc842f)

picked from #35 